### PR TITLE
[BOLT] CDSplit Main Logic Part 1/3

### DIFF
--- a/bolt/include/bolt/Passes/CDSplit.h
+++ b/bolt/include/bolt/Passes/CDSplit.h
@@ -48,8 +48,26 @@ private:
   // Conditional and unconditional successors of each BB.
   DenseMap<const BinaryBasicBlock *, JumpInfo> JumpInfos;
 
+  /// Sizes of branch instructions used to approximate block size increase
+  /// due to hot-warm splitting. Initialized to be 0. These values are updated
+  /// if the architecture is X86.
+  uint8_t BRANCH_SIZE = 0;
+  uint8_t LONG_UNCOND_BRANCH_SIZE_DELTA = 0;
+  uint8_t LONG_COND_BRANCH_SIZE_DELTA = 0;
+
   /// Helper functions to initialize global variables.
   void initialize(BinaryContext &BC);
+
+  /// Populate BinaryBasicBlock::OutputAddressRange with estimated basic block
+  /// start and end addresses for hot and warm basic blocks, assuming hot-warm
+  /// splitting happens at \p SplitIndex. Also return estimated end addresses
+  /// of the hot fragment before and after splitting.
+  /// The estimations take into account the potential addition of branch
+  /// instructions due to split fall through branches as well as the need to
+  /// use longer branch instructions for split (un)conditional branches.
+  std::pair<size_t, size_t>
+  estimatePostSplitBBAddress(const BasicBlockOrder &BlockOrder,
+                             const size_t SplitIndex);
 
   /// Split function body into 3 fragments: hot / warm / cold.
   void runOnFunction(BinaryFunction &BF);


### PR DESCRIPTION
The first diff in a series of 3 that implements the main logic of CDSplit. Under X86, function splitting can lead to block size increase. This is because conditional and unconditional branch instructions whose offset is under 8 bits can be encoded with 2 bytes. If the offset is greater than 8 bits, then they need 6 and 5 bytes respectively. Splitting a short conditional / unconditional branch will thus increase the size of the src basic block by 4 and 3 bytes respectively. CDSplit takes into account the potential block size increase when it makes splitting decisions. This diff implements a function estimatePostSplitBBAddress in CDSplit that approximates the block level size increase at the given split index of the given function.