### PR TITLE
[BOLT] CDSplit Main Logic Part 2/3

### DIFF
--- a/bolt/include/bolt/Passes/CDSplit.h
+++ b/bolt/include/bolt/Passes/CDSplit.h
@@ -18,6 +18,11 @@ namespace bolt {
 
 using BasicBlockOrder = BinaryFunction::BasicBlockOrderType;
 
+struct CallInfo {
+  size_t Length;
+  size_t Count;
+};
+
 struct JumpInfo {
   bool HasUncondBranch = false;
   BinaryBasicBlock *CondSuccessor = nullptr;
@@ -57,6 +62,12 @@ private:
 
   /// Helper functions to initialize global variables.
   void initialize(BinaryContext &BC);
+
+  /// Get a collection of "shortenable" calls, that is, calls of type X->Y
+  /// when the function order is [... X ... BF ... Y ...].
+  /// Such calls are guaranteed to get shorter (by the size of non-hot section
+  /// minus that of the total size increase).
+  std::vector<CallInfo> extractCoverCalls(const BinaryFunction &BF);
 
   /// Populate BinaryBasicBlock::OutputAddressRange with estimated basic block
   /// start and end addresses for hot and warm basic blocks, assuming hot-warm


### PR DESCRIPTION
The second diff in a series of 3 that implements the main logic of CDSplit. When the function order is [... X ... BF ... Y ...], a main benefit of splitting the hot fragment of BF further into a hot and a warm fragment is that function calls in the form of X->Y or Y->X will become shorter (i.e., SrcBB and DstBB will become closer to each other) as long as the new hot fragment of BF is smaller in size compared to the original hot fragment. This diff implements a function that finds all such "shortenable" calls in the form of X->Y or Y->X for the given function BF.